### PR TITLE
Fix missing comment highlight

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -4,3 +4,4 @@
 (string) @string
 [(identifier) (variable)] @variable
 (value) @string
+(comment) @comment


### PR DESCRIPTION
Here's before and after

![Screenshot 2025-01-26 at 23 11 00](https://github.com/user-attachments/assets/dc566d85-2abf-475e-9108-cbb67ebe0893)
